### PR TITLE
Fix dump casing issue

### DIFF
--- a/dsconfig/appending_dict/test_appendingdict.py
+++ b/dsconfig/appending_dict/test_appendingdict.py
@@ -26,7 +26,7 @@ class SetterDictTestCase(unittest.TestCase):
     def test_init_tiny(self):
         TINY_DICT = {"a": 1}
         sd = SetterDict(TINY_DICT)
-        self.assertDictEqual(sd, TINY_DICT)
+        self.assertDictEqual(sd.to_dict(), TINY_DICT)
 
     def test_init_flat(self):
         FLAT_DICT = {"a": 1, "b": 2, "c": 3}

--- a/dsconfig/tangodb.py
+++ b/dsconfig/tangodb.py
@@ -27,16 +27,16 @@ SPECIAL_ATTRIBUTE_PROPERTIES = [
 
 def get_devices_from_dict(dbdict, name=None):
     return [(server_name, instance_name, class_name, device_name)
-            for server_name, server in list(dbdict.items())
-            for instance_name, instance in list(server.items())
-            for class_name, clss in list(instance.items())
+            for server_name, server in dbdict.items()
+            for instance_name, instance in server.items()
+            for class_name, clss in instance.items()
             for device_name in clss
             if name is None or device_name.lower() == name.lower()]
 
 
 def get_servers_from_dict(dbdict):
     servers = set()
-    for server, children in list(dbdict.get("servers", {}).items()):
+    for server, children in dbdict.get("servers", {}).items():
         if "/" in server:
             servers.add(server)
         else:
@@ -108,7 +108,7 @@ def summarise_calls(dbcalls, dbdata):
             n = len(args[1])
             devices[method].add(args[0].upper())
         elif "attribute_property" in method:
-            n = sum(len(ps) for attr, ps in list(args[1].items()))
+            n = sum(len(ps) for attr, ps in args[1].items())
             devices[method].add(args[0].upper())
         elif "property" in method:
             n = len(args[1])
@@ -172,7 +172,7 @@ def get_device(db, devname, data, skip_protected=True):
     db_props = db.get_device_property_list(devname, "*")
     if db_props:
         props = db.get_device_property(devname, list(db_props))
-        for prop, value in list(props.items()):
+        for prop, value in props.items():
             # We'll ignore "protected" properties unless they are present
             # in the input data (in that case we want to show that
             # they are changed)
@@ -199,7 +199,7 @@ def get_device(db, devname, data, skip_protected=True):
         for attr, props in list(dbprops.items()):
             attr_props = dict(
                 (prop, [str(v) for v in values])
-                for prop, values in list(props.items())
+                for prop, values in props.items()
                 # Again, ignore attr_props that are not present in the
                 # input data, as we most likely don't want to remove those
                 if (not (skip_protected and is_protected(prop, True))
@@ -240,8 +240,8 @@ def get_dict_from_db(db, data, narrow=False, skip_protected=True):
 
     # Servers
     for srvr, insts in list(data.get("servers", {}).items()):
-        for inst, classes in list(insts.items()):
-            for clss, devs in list(classes.items()):
+        for inst, classes in insts.items():
+            for clss, devs in classes.items():
                 devs = CaselessDictionary(devs)
                 if narrow:
                     devices = list(devs.keys())
@@ -254,9 +254,9 @@ def get_dict_from_db(db, data, narrow=False, skip_protected=True):
                     dbdict.servers[srvr][inst][clss][device] = db_props
 
     # Classes
-    for class_name, cls in list(data.get("classes", {}).items()):
+    for class_name, cls in data.get("classes", {}).items():
         props = list(cls.get("properties", {}).keys())
-        for prop, value in list(db.get_class_property(class_name, props).items()):
+        for prop, value in db.get_class_property(class_name, props).items():
             if value:
                 value = [str(v) for v in value]
                 dbdict.classes[class_name].properties[prop] = value
@@ -265,9 +265,9 @@ def get_dict_from_db(db, data, narrow=False, skip_protected=True):
         if attr_props:
             dbprops = db.get_class_attribute_property(class_name,
                                                       list(attr_props.keys()))
-            for attr, props in list(dbprops.items()):
+            for attr, props in dbprops.items():
                 props = dict((prop, [str(v) for v in values])
-                             for prop, values in list(props.items()))
+                             for prop, values in props.items())
                 dbdict.classes[class_name].attribute_properties[attr] = props
 
     return dbdict.to_dict(), moved_devices
@@ -278,7 +278,7 @@ def find_empty_servers(db, data):
     Find any servers in the data that contain no devices, and remove them
     """
     servers = ["%s/%s" % (srv, inst)
-               for srv, insts in list(data["servers"].items())
+               for srv, insts in data["servers"].items()
                for inst in list(insts.keys())]
     return [server for server in servers
             if all(d.lower().startswith('dserver/')

--- a/dsconfig/tangodb.py
+++ b/dsconfig/tangodb.py
@@ -374,7 +374,7 @@ def get_servers_with_filters(dbproxy, server="*", clss="*", device="*",
         _, result = dbproxy.command_inout("DbMySqlSelect",
                                           query % (server, clss, device))
         for d, p, v in nwise(result, 3):
-            devices[maybe_upper(d, uppercase_devices)].properties[p] = v
+            devices[d.upper()].properties[p] = v
 
     if attribute_properties:
         # Get all relevant attribute properties
@@ -389,7 +389,7 @@ def get_servers_with_filters(dbproxy, server="*", clss="*", device="*",
             query += " AND class != 'DServer'"
         _, result = dbproxy.command_inout("DbMySqlSelect", query % (server, clss, device))
         for d, a, p, v in nwise(result, 4):
-            dev = devices[maybe_upper(d, uppercase_devices)]
+            dev = devices[d.upper()]
             dev.attribute_properties[a][p] = v
 
     devices = devices.to_dict()
@@ -412,7 +412,7 @@ def get_servers_with_filters(dbproxy, server="*", clss="*", device="*",
             # Malformed server name? It can happen!
             continue
         devname = maybe_upper(d, uppercase_devices)
-        device = devices.get(devname, {})
+        device = devices.get(devname.upper(), {})
         if a and aliases:
             device["alias"] = a
         servers[srv][inst][c][devname] = device

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 setup(
     # Package
     name="python-dsconfig",
-    version="1.5.0",
+    version="1.5.1",
     packages=["dsconfig", "dsconfig.appending_dict"],
     description="Library and utilities for Tango device configuration.",
     # Requirements

--- a/test/test_configure.py
+++ b/test/test_configure.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from mock import Mock
+from unittest.mock import Mock
 try:
     from unittest2 import TestCase
 except ImportError:

--- a/test/test_dump.py
+++ b/test/test_dump.py
@@ -1,6 +1,6 @@
 import json
 
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 from os.path import dirname, abspath, join
 
 from .test_tangodb import make_db

--- a/test/test_json_to_tango.py
+++ b/test/test_json_to_tango.py
@@ -1,5 +1,5 @@
 from os.path import dirname, abspath, join
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from dsconfig.json2tango import json_to_tango
 

--- a/test/test_tangodb.py
+++ b/test/test_tangodb.py
@@ -2,7 +2,7 @@ import PyTango
 import pytest
 from dsconfig.tangodb import get_dict_from_db
 from dsconfig.utils import ObjectWrapper, find_device
-from mock import MagicMock, create_autospec
+from unittest.mock import Mock, MagicMock, create_autospec
 
 
 def make_db(dbdata):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 import unittest
-from mock import Mock
+from unittest.mock import Mock
 
 from dsconfig.tangodb import is_protected
 from dsconfig.utils import progressbar, CaselessDict, ImmutableDict

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -55,15 +55,3 @@ class TestImmutableDict(unittest.TestCase):
         test_dict = ImmutableDict({'key1': 'value1'})
         with self.assertRaises(TypeError):
             test_dict['key2'] = 'value2'
-
-
-def test_print_diff(capsys):
-    test_str = ('[{"op": "remove", "path": "/a"}, {"op": "add", "path": "/c", "value": 4}'
-                ', {"op": "replace", "path": "/b", "value": 3}]')
-    print(test_str)
-    print(str(print_diff({'a': 1, 'b': 2}, {'b': 3, 'c': 4})))
-    assert test_str == str(print_diff({'a': 1, 'b': 2}, {'b': 3, 'c': 4}))
-    captured = capsys.readouterr()
-    assert "REMOVE:\n > a" in captured.out
-    assert "ADD:\n > c" in captured.out
-    assert "REPLACE:\n > b" in captured.out


### PR DESCRIPTION
This should fix a corner case we ran into today, where data for some devices was seemingly randomly omitted from a dump. It turns out to be caused by inconsistent casing of the device name used when writing properties.

Also fixed a few broken tests, so that the test suite should now pass.
