### PR TITLE
Property value order

### DIFF
--- a/dsconfig/tangodb.py
+++ b/dsconfig/tangodb.py
@@ -287,9 +287,10 @@ def find_empty_servers(db, data):
 
 def get_device_property_values(dbproxy, device, name="*",
                                include_subdevices=False):
-    query = ("SELECT name, value FROM property_device "
+    query = ("SELECT name, value "
+             "FROM property_device "
              "WHERE device = '%s' AND name LIKE '%s' "
-             "ORDER BY property_device.count ASC")
+             "ORDER BY count ASC")
     _, result = dbproxy.command_inout("DbMySqlSelect",
                                       query % (device, name.replace("*", "%")))
     data = defaultdict(list)
@@ -300,9 +301,10 @@ def get_device_property_values(dbproxy, device, name="*",
 
 
 def get_device_attribute_property_values(dbproxy, device, name="*"):
-    query = ("SELECT attribute, name, value FROM property_attribute_device "
+    query = ("SELECT attribute, name, value "
+             "FROM property_attribute_device "
              "WHERE device = '%s' AND name LIKE '%s' "
-             "ORDER BY property_attribute_device.count ASC")
+             "ORDER BY count ASC")
     _, result = dbproxy.command_inout("DbMySqlSelect",
                                       query % (device, name.replace("*", "%")))
     data = AppendingDict()

--- a/dsconfig/tangodb.py
+++ b/dsconfig/tangodb.py
@@ -288,7 +288,8 @@ def find_empty_servers(db, data):
 def get_device_property_values(dbproxy, device, name="*",
                                include_subdevices=False):
     query = ("SELECT name, value FROM property_device "
-             "WHERE device = '%s' AND name LIKE '%s'")
+             "WHERE device = '%s' AND name LIKE '%s' "
+             "ORDER BY property_device.count ASC")
     _, result = dbproxy.command_inout("DbMySqlSelect",
                                       query % (device, name.replace("*", "%")))
     data = defaultdict(list)
@@ -300,7 +301,8 @@ def get_device_property_values(dbproxy, device, name="*",
 
 def get_device_attribute_property_values(dbproxy, device, name="*"):
     query = ("SELECT attribute, name, value FROM property_attribute_device "
-             "WHERE device = '%s' AND name LIKE '%s'")
+             "WHERE device = '%s' AND name LIKE '%s' "
+             "ORDER BY property_attribute_device.count ASC")
     _, result = dbproxy.command_inout("DbMySqlSelect",
                                       query % (device, name.replace("*", "%")))
     data = AppendingDict()
@@ -371,6 +373,7 @@ def get_servers_with_filters(dbproxy, server="*", clss="*", device="*",
             query += " AND class != 'DServer'"
         if not subdevices:
             query += " AND property_device.name != '__SubDevices'"
+        query += " ORDER BY property_device.count ASC"
         _, result = dbproxy.command_inout("DbMySqlSelect",
                                           query % (server, clss, device))
         for d, p, v in nwise(result, 3):
@@ -387,6 +390,7 @@ def get_servers_with_filters(dbproxy, server="*", clss="*", device="*",
             " WHERE server LIKE '%s' AND class LIKE '%s' AND device LIKE '%s'")
         if not dservers:
             query += " AND class != 'DServer'"
+        query += " ORDER BY property_attribute_device.count ASC"
         _, result = dbproxy.command_inout("DbMySqlSelect", query % (server, clss, device))
         for d, a, p, v in nwise(result, 4):
             dev = devices[d.upper()]
@@ -442,7 +446,8 @@ def get_classes_properties(dbproxy, server='*', cls_properties=True,
             "ON property_class.class = device.class "
             "WHERE server like '%s' "
             "AND device.class != 'DServer' "
-            "AND device.class != 'TangoAccessControl'")
+            "AND device.class != 'TangoAccessControl' "
+            "ORDER BY property_class.count ASC")
         _, result = dbproxy.command_inout("DbMySqlSelect", querry % (server))
         # Build the output based on: class, property: value
         for c, p, v in nwise(result, 3):
@@ -459,7 +464,8 @@ def get_classes_properties(dbproxy, server='*', cls_properties=True,
             "ON property_attribute_class.class = device.class "
             "WHERE server like '%s' "
             "AND device.class != 'DServer' "
-            "AND device.class != 'TangoAccessControl'")
+            "AND device.class != 'TangoAccessControl' "
+            "ORDER BY property_attribute_class.count ASC")
         _, result = dbproxy.command_inout("DbMySqlSelect", querry % (server))
         # Build output: class, attribute, property: value
         for c, a, p, v in nwise(result, 4):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 setup(
     # Package
     name="python-dsconfig",
-    version="1.5.1",
+    version="1.5.2",
     packages=["dsconfig", "dsconfig.appending_dict"],
     description="Library and utilities for Tango device configuration.",
     # Requirements

--- a/test/test_dump.py
+++ b/test/test_dump.py
@@ -10,38 +10,52 @@ from dsconfig.dump import get_db_data
 query1 = ("SELECT device, property_device.name, property_device.value FROM "
           "property_device INNER JOIN device ON property_device.device = device.name "
           "WHERE server LIKE '%' AND class LIKE '%' AND device LIKE '%' AND "
-          "class != 'DServer' AND property_device.name != '__SubDevices'")
+          "class != 'DServer' AND property_device.name != '__SubDevices' "
+          "ORDER BY property_device.count ASC")
+          
 query2 = ("SELECT device, attribute, property_attribute_device.name, "
           "property_attribute_device.value FROM property_attribute_device INNER JOIN "
           "device ON property_attribute_device.device = device.name WHERE server "
-          "LIKE '%' AND class LIKE '%' AND device LIKE '%' AND class != 'DServer'")
+          "LIKE '%' AND class LIKE '%' AND device LIKE '%' AND class != 'DServer' "
+          "ORDER BY property_attribute_device.count ASC")
+          
 query3 = ("SELECT server, class, name, alias FROM device WHERE server LIKE '%' AND "
           "class LIKE '%' AND name LIKE '%' AND class != 'DServer'")
+          
 query4 = ("select DISTINCT property_class.class, property_class.name, "
           "property_class.value FROM property_class INNER JOIN device ON "
           "property_class.class = device.class WHERE server like '%' AND "
-          "device.class != 'DServer' AND device.class != 'TangoAccessControl'")
+          "device.class != 'DServer' AND device.class != 'TangoAccessControl' "
+          "ORDER BY property_class.count ASC")
+          
 query5 = ("select DISTINCT  property_attribute_class.class, "
           "property_attribute_class.attribute, property_attribute_class.name, "
           "property_attribute_class.value FROM property_attribute_class INNER JOIN "
           "device ON property_attribute_class.class = device.class WHERE server "
           "like '%' AND device.class != 'DServer' AND "
-          "device.class != 'TangoAccessControl'")
+          "device.class != 'TangoAccessControl' "
+          "ORDER BY property_attribute_class.count ASC")
+          
 query6 = ("select DISTINCT  property_attribute_class.class, "
           "property_attribute_class.attribute, property_attribute_class.name, "
           "property_attribute_class.value FROM property_attribute_class INNER JOIN "
           "device ON property_attribute_class.class = device.class WHERE server "
           "like 'SOMEDEVICE' AND device.class != 'DServer' AND "
-          "device.class != 'TangoAccessControl'")
+          "device.class != 'TangoAccessControl' "
+          "ORDER BY property_attribute_class.count ASC")
+          
 query7 = ("select DISTINCT property_class.class, property_class.name, "
           "property_class.value FROM property_class INNER JOIN device ON "
           "property_class.class = device.class WHERE server like 'SOMEDEVICE' AND "
-          "device.class != 'DServer' AND device.class != 'TangoAccessControl'")
+          "device.class != 'DServer' AND device.class != 'TangoAccessControl' "
+          "ORDER BY property_class.count ASC")
+          
 query8 = ("SELECT device, attribute, property_attribute_device.name, "
           "property_attribute_device.value FROM property_attribute_device INNER JOIN "
           "device ON property_attribute_device.device = device.name WHERE server "
           "LIKE 'SOMESERVER' AND class LIKE '%' AND device LIKE '%' AND "
-          "class != 'DServer'")
+          "class != 'DServer' "
+          "ORDER BY property_attribute_device.count ASC")
 
 
 def test_db_dump():


### PR DESCRIPTION
Fix for issue with inconsistent property value order read from DB by dsconfig. This happens very rarely though.

This is caused by the SQL query in dsconfig that doesn't always return the device property values list in the same order. Hence the json2tango script is not idempotent when this happens.

The property_device table in tango has a count column that gives the correct row number of the property value list even if the order is wrong. The inconsistent order issue can be avoided by adding the following line to the SQL query in dsconfig.
" ORDER BY property_device.count ASC"